### PR TITLE
feat(settings): add settings page and integrate calculations

### DIFF
--- a/apps/farming-game-calc-e2e/cypress.config.ts
+++ b/apps/farming-game-calc-e2e/cypress.config.ts
@@ -2,15 +2,7 @@ const { nxE2EPreset } = require('@nx/cypress/plugins/cypress-preset');
 const { defineConfig } = require('cypress');
 module.exports = defineConfig({
   e2e: {
-    ...nxE2EPreset(__filename, {
-      cypressDir: 'src',
-      webServerCommands: {
-        default: 'npx nx run farming-game-calc:serve',
-        production: 'npx nx run farming-game-calc:serve-static',
-      },
-      ciWebServerCommand: 'npx nx run farming-game-calc:serve-static',
-      ciBaseUrl: 'http://localhost:4200',
-    }),
+    ...nxE2EPreset(__filename, { bundler: 'vite' }),
     baseUrl: 'http://localhost:4200',
   },
 });

--- a/apps/farming-game-calc-e2e/project.json
+++ b/apps/farming-game-calc-e2e/project.json
@@ -5,6 +5,19 @@
   "sourceRoot": "apps/farming-game-calc-e2e/src",
   "tags": [],
   "implicitDependencies": ["farming-game-calc"],
-  "// targets": "to see all targets run: nx show project farming-game-calc-e2e --web",
-  "targets": {}
+  "targets": {
+    "e2e": {
+      "executor": "@nx/cypress:cypress",
+      "options": {
+        "cypressConfig": "apps/farming-game-calc-e2e/cypress.config.ts",
+        "devServerTarget": "farming-game-calc:serve:development",
+        "testingType": "e2e"
+      },
+      "configurations": {
+        "production": {
+          "devServerTarget": "farming-game-calc:serve:production"
+        }
+      }
+    }
+  }
 }

--- a/apps/farming-game-calc-e2e/src/e2e/app.cy.ts
+++ b/apps/farming-game-calc-e2e/src/e2e/app.cy.ts
@@ -1,13 +1,62 @@
-import { getGreeting } from '../support/app.po';
+import {
+  getTotalText,
+  goBackToMainPage,
+  openSettings,
+  selectCharacter,
+  setInputValue,
+} from '../support/app.po';
 
 describe('farming-game-calc-e2e', () => {
-  beforeEach(() => cy.visit('/'));
+  beforeEach(() => {
+    cy.visit('/');
+    cy.window().then((window) => {
+      window.sessionStorage.clear();
+    });
+    cy.reload();
+  });
 
-  it('should display welcome message', () => {
-    // Custom command example, see `../support/commands.ts` file
-    cy.login('my-email@something.com', 'myPassword');
+  it('navigates to settings from toolbar and back to main page', () => {
+    openSettings();
 
-    // Function helper example, see `../support/app.po.ts` file
-    getGreeting().contains(/Welcome/);
+    cy.contains('Settings').should('be.visible');
+    goBackToMainPage();
+    cy.contains('Farming Game Net Asset Calculator').should('be.visible');
+  });
+
+  it('persists updated settings and reflects price changes on main page', () => {
+    openSettings();
+
+    setInputValue('input#hayPricePerAcre', 3000);
+    setInputValue('input#playerCount', 3);
+    selectCharacter(0, 'Satus Sam');
+    selectCharacter(1, 'Toppenish Tom');
+    selectCharacter(2, 'Roza Ray');
+
+    cy.get('input#hayPricePerAcre').should('have.value', '3000');
+    cy.get('input#playerCount').should('have.value', '3');
+
+    goBackToMainPage();
+    getTotalText().should('contain.text', '$50,000');
+
+    openSettings();
+    cy.reload();
+
+    cy.get('input#hayPricePerAcre').should('have.value', '3000');
+    cy.get('input#playerCount').should('have.value', '3');
+    cy.get('#playerCharacter0 option:selected').should(
+      'contain.text',
+      'Satus Sam',
+    );
+    cy.get('#playerCharacter1 option:selected').should(
+      'contain.text',
+      'Toppenish Tom',
+    );
+    cy.get('#playerCharacter2 option:selected').should(
+      'contain.text',
+      'Roza Ray',
+    );
+
+    goBackToMainPage();
+    getTotalText().should('contain.text', '$50,000');
   });
 });

--- a/apps/farming-game-calc-e2e/src/support/app.po.ts
+++ b/apps/farming-game-calc-e2e/src/support/app.po.ts
@@ -1,1 +1,17 @@
-export const getGreeting = () => cy.get('h1');
+export const openSettings = () =>
+  cy.get('[aria-label="Open settings"]').click();
+
+export const goBackToMainPage = () =>
+  cy.get('[aria-label="Back to main page"]').click();
+
+export const setInputValue = (selector: string, value: string | number) =>
+  cy
+    .get(selector)
+    .invoke('val', String(value))
+    .trigger('input')
+    .trigger('change');
+
+export const selectCharacter = (playerIndex: number, character: string) =>
+  cy.get(`#playerCharacter${playerIndex}`).select(character);
+
+export const getTotalText = () => cy.get('#totalAmount h3');

--- a/apps/farming-game-calc-e2e/tsconfig.json
+++ b/apps/farming-game-calc-e2e/tsconfig.json
@@ -1,24 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "moduleResolution": "bundler",
-    "allowJs": true,
-    "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["cypress", "node"],
     "sourceMap": false,
+    "outDir": "../../dist/out-tsc",
+    "allowJs": true,
+    "types": ["cypress", "node"],
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "**/*.ts",
-    "**/*.js",
-    "cypress.config.ts",
-    "**/*.cy.ts",
-    "**/*.cy.js",
-    "**/*.d.ts"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.js", "cypress.config.ts"]
 }

--- a/apps/farming-game-calc/src/app/app-routing.module.ts
+++ b/apps/farming-game-calc/src/app/app-routing.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AboutPageComponent } from './pages/about-page/about-page.component';
 import { MainPageComponent } from './pages/main-page/main-page.component';
+import { SettingsPageComponent } from './pages/settings-page/settings-page.component';
 
 const routes: Routes = [
   { path: '', component: MainPageComponent },
   { path: 'about', component: AboutPageComponent },
+  { path: 'settings', component: SettingsPageComponent },
 ];
 
 @NgModule({

--- a/apps/farming-game-calc/src/app/app.module.ts
+++ b/apps/farming-game-calc/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { DollarAmountInputComponent } from './dollar-amount-input/dollar-amount-
 import { TouchCheckboxComponent } from './touch-checkbox/touch-checkbox.component';
 import { AboutPageComponent } from './pages/about-page/about-page.component';
 import { MainPageComponent } from './pages/main-page/main-page.component';
+import { SettingsPageComponent } from './pages/settings-page/settings-page.component';
 import { provideServiceWorker } from '@angular/service-worker';
 
 @NgModule({
@@ -22,6 +23,7 @@ import { provideServiceWorker } from '@angular/service-worker';
     TouchCheckboxComponent,
     AboutPageComponent,
     MainPageComponent,
+    SettingsPageComponent,
   ],
   imports: [
     BrowserModule,

--- a/apps/farming-game-calc/src/app/pages/about-page/about-page.component.html
+++ b/apps/farming-game-calc/src/app/pages/about-page/about-page.component.html
@@ -1,11 +1,11 @@
 <nav class="navbar navbar-dark bg-dark">
-  <a routerLink="">
+  <a class="ms-2" routerLink="">
     <fa-icon
       [icon]="faBackIcon"
       class="fa fa-chevron-left text-light pe-2"
     ></fa-icon>
   </a>
-  <span class="text-light me-auto"
+  <span class="text-light ms-2 me-2 flex-grow-1"
     >About Farming Game Net Asset Calculator</span
   >
 </nav>

--- a/apps/farming-game-calc/src/app/pages/main-page/main-page.component.html
+++ b/apps/farming-game-calc/src/app/pages/main-page/main-page.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-dark bg-dark">
-  <span class="text-light">Farming Game Net Asset Calculator</span>
-  <a routerLink="settings" aria-label="Open settings">
+  <span class="text-light ms-2">Farming Game Net Asset Calculator</span>
+  <a class="me-2" routerLink="settings" aria-label="Open settings">
     <fa-icon [icon]="faSettingsIcon" class="text-light"></fa-icon>
   </a>
 </nav>

--- a/apps/farming-game-calc/src/app/pages/main-page/main-page.component.html
+++ b/apps/farming-game-calc/src/app/pages/main-page/main-page.component.html
@@ -1,5 +1,8 @@
 <nav class="navbar navbar-dark bg-dark">
   <span class="text-light">Farming Game Net Asset Calculator</span>
+  <a routerLink="settings" aria-label="Open settings">
+    <fa-icon [icon]="faSettingsIcon" class="text-light"></fa-icon>
+  </a>
 </nav>
 <div class="container mt-2">
   <app-touch-input-spinner

--- a/apps/farming-game-calc/src/app/pages/main-page/main-page.component.spec.ts
+++ b/apps/farming-game-calc/src/app/pages/main-page/main-page.component.spec.ts
@@ -7,22 +7,24 @@ import { TouchCheckboxComponent } from '../../touch-checkbox/touch-checkbox.comp
 import { TouchInputSpinnerComponent } from '../../touch-input-spinner/touch-input-spinner.component';
 import { DollarAmountInputComponent } from '../../dollar-amount-input/dollar-amount-input.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import {
+  SettingsService,
+  SETTINGS_STORAGE_KEY,
+} from '../../settings/settings.service';
 
 describe('MainPageComponent', () => {
   beforeEach(waitForAsync(() => {
+    sessionStorage.removeItem(SETTINGS_STORAGE_KEY);
+
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        FormsModule,
-        FontAwesomeModule
-      ],
+      imports: [RouterTestingModule, FormsModule, FontAwesomeModule],
       declarations: [
         MainPageComponent,
         TouchCheckboxComponent,
-        TouchCheckboxComponent,
         TouchInputSpinnerComponent,
-        DollarAmountInputComponent
+        DollarAmountInputComponent,
       ],
+      providers: [SettingsService],
     }).compileComponents();
   }));
 
@@ -43,7 +45,9 @@ describe('MainPageComponent', () => {
     const fixture = TestBed.createComponent(MainPageComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('#totalAmount').textContent).toContain('$40,000');
+    expect(compiled.querySelector('#totalAmount').textContent).toContain(
+      '$40,000',
+    );
   });
 
   it('should calculate the total amount from all different amounts', () => {
@@ -88,7 +92,6 @@ describe('MainPageComponent', () => {
     expect(app.hayAcres).toEqual(100);
     expect(app.hayAmount).toEqual(200000);
     expect(app.totalAmount).toEqual(220000); // includes Grain Amount
-
   });
 
   it('should update Grain acres and amounts when Grain acres are changed', () => {
@@ -100,7 +103,6 @@ describe('MainPageComponent', () => {
     expect(app.grainAcres).toEqual(100);
     expect(app.grainAmount).toEqual(200000);
     expect(app.totalAmount).toEqual(220000); // includes Hay Amount
-
   });
 
   it('should update Fruit acres and amounts when Fruit acres are changed', () => {
@@ -112,7 +114,6 @@ describe('MainPageComponent', () => {
     expect(app.fruitAcres).toEqual(100);
     expect(app.fruitAmount).toEqual(500000);
     expect(app.totalAmount).toEqual(540000); // includes Hay and Grain Amounts
-
   });
 
   it('should update number of cows and amounts when Cows are changed', () => {
@@ -124,7 +125,6 @@ describe('MainPageComponent', () => {
     expect(app.numberOfCows).toEqual(100);
     expect(app.cowAmount).toEqual(50000);
     expect(app.totalAmount).toEqual(90000); // includes Hay and Grain Amounts
-
   });
 
   it('should update total amount when Has Tractor is changed', () => {
@@ -142,7 +142,6 @@ describe('MainPageComponent', () => {
     expect(app.hasTractor).toBeFalsy();
     expect(app.tractorAmount).toEqual(0);
     expect(app.totalAmount).toEqual(40000); // includes Hay and Grain Amounts (40000)
-
   });
 
   it('should update total amount when Has Harvested is changed', () => {
@@ -252,6 +251,39 @@ describe('MainPageComponent', () => {
     expect(app.hasHarvesterValue).toBeFalsy();
     expect(app.cashInHand).toBeNull();
     expect(app.debt).toBeNull();
+  });
 
+  it('should use customized settings prices in calculations', () => {
+    const settingsService = TestBed.inject(SettingsService);
+    settingsService.setPrice('hayPricePerAcre', 3000);
+
+    const fixture = TestBed.createComponent(MainPageComponent);
+    const app: MainPageComponent = fixture.debugElement.componentInstance;
+
+    app.hayAcresChanged(20);
+
+    expect(app.hayAmount).toEqual(60000);
+    expect(app.totalAmount).toEqual(80000);
+  });
+
+  it('should keep customized settings on reset', () => {
+    const settingsService = TestBed.inject(SettingsService);
+    settingsService.setPrice('hayPricePerAcre', 3000);
+    settingsService.setPrice('grainPricePerAcre', 2500);
+
+    const fixture = TestBed.createComponent(MainPageComponent);
+    const app: MainPageComponent = fixture.debugElement.componentInstance;
+
+    app.hayAcresChanged(5);
+    app.grainAcresChanged(5);
+    app.cowsChanged(10);
+
+    app.onResetClicked();
+
+    expect(app.hayAmount).toEqual(30000);
+    expect(app.grainAmount).toEqual(25000);
+    expect(app.totalAmount).toEqual(55000);
+    expect(app.fruitAmount).toEqual(0);
+    expect(app.cowAmount).toEqual(0);
   });
 });

--- a/apps/farming-game-calc/src/app/pages/main-page/main-page.component.ts
+++ b/apps/farming-game-calc/src/app/pages/main-page/main-page.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { faGear, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { SettingsService } from '../../settings/settings.service';
 
 @Component({
   selector: 'app-main-page',
@@ -7,9 +9,10 @@ import { Component } from '@angular/core';
   styleUrls: ['./main-page.component.scss'],
 })
 export class MainPageComponent {
-  totalAmount = 40000;
-  hayAmount = 20000;
-  grainAmount = 20000;
+  faSettingsIcon: IconDefinition = faGear;
+  totalAmount = 0;
+  hayAmount = 0;
+  grainAmount = 0;
   fruitAmount = 0;
   cowAmount = 0;
   tractorAmount = 0;
@@ -26,40 +29,50 @@ export class MainPageComponent {
   hasTractor = false;
   hasHarvesterValue = false;
 
+  constructor(private readonly settingsService: SettingsService) {
+    this.recalculateFromCurrentValues();
+    this.calculateTotal();
+  }
+
   hayAcresChanged(input: number) {
-    console.log(input);
     this.hayAcres = input;
-    this.hayAmount = input * 2000;
+    this.hayAmount = input * this.settingsService.getSettings().hayPricePerAcre;
     this.calculateTotal();
   }
 
   grainAcresChanged(input: number) {
     this.grainAcres = input;
-    this.grainAmount = input * 2000;
+    this.grainAmount =
+      input * this.settingsService.getSettings().grainPricePerAcre;
     this.calculateTotal();
   }
 
   fruitAcresChanged(input: number) {
     this.fruitAcres = input;
-    this.fruitAmount = input * 5000;
+    this.fruitAmount =
+      input * this.settingsService.getSettings().fruitPricePerAcre;
     this.calculateTotal();
   }
 
   cowsChanged(input: number) {
     this.numberOfCows = input;
-    this.cowAmount = input * 500;
+    this.cowAmount = input * this.settingsService.getSettings().cowPrice;
     this.calculateTotal();
   }
 
   tractorChanged(checked: boolean) {
     this.hasTractor = checked;
-    this.tractorAmount = checked ? 10000 : 0;
+    this.tractorAmount = checked
+      ? this.settingsService.getSettings().tractorPrice
+      : 0;
     this.calculateTotal();
   }
 
   harvesterChanged(checked: boolean) {
     this.hasHarvesterValue = checked;
-    this.harvesterAmount = checked ? 10000 : 0;
+    this.harvesterAmount = checked
+      ? this.settingsService.getSettings().harvesterPrice
+      : 0;
     this.calculateTotal();
   }
 
@@ -102,15 +115,19 @@ export class MainPageComponent {
     this.debt = null;
     this.hasHarvesterValue = false;
     this.hasTractor = false;
-    this.totalAmount = 40000;
-    this.hayAmount = 20000;
-    this.grainAmount = 20000;
-    this.fruitAmount = 0;
-    this.cowAmount = 0;
-    this.tractorAmount = 0;
-    this.harvesterAmount = 0;
+    this.recalculateFromCurrentValues();
     this.cashAmount = 0;
     this.debtAmount = 0;
     this.calculateTotal();
+  }
+
+  private recalculateFromCurrentValues() {
+    const settings = this.settingsService.getSettings();
+    this.hayAmount = this.hayAcres * settings.hayPricePerAcre;
+    this.grainAmount = this.grainAcres * settings.grainPricePerAcre;
+    this.fruitAmount = (this.fruitAcres || 0) * settings.fruitPricePerAcre;
+    this.cowAmount = (this.numberOfCows || 0) * settings.cowPrice;
+    this.tractorAmount = this.hasTractor ? settings.tractorPrice : 0;
+    this.harvesterAmount = this.hasHarvesterValue ? settings.harvesterPrice : 0;
   }
 }

--- a/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.html
+++ b/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.html
@@ -1,0 +1,68 @@
+<nav class="navbar navbar-dark bg-dark">
+  <a routerLink="" aria-label="Back to main page">
+    <fa-icon
+      [icon]="faBackIcon"
+      class="fa fa-chevron-left text-light pe-2"
+    ></fa-icon>
+  </a>
+  <span class="text-light me-auto">Settings</span>
+</nav>
+
+<div class="container mt-2">
+  <div class="card mb-2">
+    <div class="card-body">
+      <h5 class="card-title">Price Settings</h5>
+      <p class="card-text text-muted mb-3">
+        Changes are saved to this browser tab using session storage.
+      </p>
+      <div class="row g-2">
+        <div class="col-12 col-md-6" *ngFor="let field of priceFields">
+          <label class="form-label" [for]="field.key">{{ field.label }}</label>
+          <div class="input-group">
+            <span class="input-group-text">$</span>
+            <input
+              [id]="field.key"
+              class="form-control"
+              type="number"
+              min="0"
+              [ngModel]="settings[field.key]"
+              (ngModelChange)="onPriceChanged(field.key, $event)"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">Players</h5>
+      <app-touch-input-spinner
+        id="playerCount"
+        [step]="1"
+        [min]="1"
+        [ngModel]="settings.playerCount"
+        (ngModelChange)="onPlayerCountChanged($event)"
+      >
+        Number of Players
+      </app-touch-input-spinner>
+
+      <div class="mt-3" *ngFor="let slot of playerSlots">
+        <label class="form-label" [for]="'playerCharacter' + slot">
+          Player {{ slot + 1 }} Character
+        </label>
+        <select
+          class="form-select"
+          [id]="'playerCharacter' + slot"
+          [ngModel]="settings.playerCharacters[slot]"
+          (ngModelChange)="onPlayerCharacterChanged(slot, $event)"
+        >
+          <option value="">Select a character</option>
+          <option *ngFor="let character of characters" [ngValue]="character">
+            {{ character }}
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.html
+++ b/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.html
@@ -1,11 +1,11 @@
 <nav class="navbar navbar-dark bg-dark">
-  <a routerLink="" aria-label="Back to main page">
+  <a class="ms-2" routerLink="" aria-label="Back to main page">
     <fa-icon
       [icon]="faBackIcon"
       class="fa fa-chevron-left text-light pe-2"
     ></fa-icon>
   </a>
-  <span class="text-light me-auto">Settings</span>
+  <span class="text-light ms-2 me-2 flex-grow-1">Settings</span>
 </nav>
 
 <div class="container mt-2">

--- a/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.scss
+++ b/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.scss
@@ -1,0 +1,3 @@
+.card-title {
+  margin-bottom: 0.5rem;
+}

--- a/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.spec.ts
+++ b/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.spec.ts
@@ -1,0 +1,62 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TouchInputSpinnerComponent } from '../../touch-input-spinner/touch-input-spinner.component';
+import {
+  SETTINGS_STORAGE_KEY,
+  SettingsService,
+} from '../../settings/settings.service';
+import { SettingsPageComponent } from './settings-page.component';
+
+describe('SettingsPageComponent', () => {
+  let component: SettingsPageComponent;
+  let fixture: ComponentFixture<SettingsPageComponent>;
+
+  beforeEach(waitForAsync(() => {
+    sessionStorage.removeItem(SETTINGS_STORAGE_KEY);
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, FormsModule, FontAwesomeModule],
+      declarations: [SettingsPageComponent, TouchInputSpinnerComponent],
+      providers: [SettingsService],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render default settings values', () => {
+    const compiled: HTMLElement = fixture.debugElement.nativeElement;
+    const hayInput = compiled.querySelector(
+      '#hayPricePerAcre',
+    ) as HTMLInputElement;
+
+    expect(hayInput.value).toBe('2000');
+    expect(component.settings.playerCount).toBe(1);
+    expect(component.playerSlots.length).toBe(1);
+  });
+
+  it('should update player slots after changing player count', () => {
+    component.onPlayerCountChanged(3);
+
+    expect(component.settings.playerCount).toBe(3);
+    expect(component.playerSlots.length).toBe(3);
+    expect(component.settings.playerCharacters.length).toBe(3);
+  });
+
+  it('should persist selected characters', () => {
+    component.onPlayerCountChanged(2);
+    component.onPlayerCharacterChanged(0, 'Toppenish Tom');
+
+    const settings = TestBed.inject(SettingsService).getSettings();
+    expect(settings.playerCharacters[0]).toBe('Toppenish Tom');
+  });
+});

--- a/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.ts
+++ b/apps/farming-game-calc/src/app/pages/settings-page/settings-page.component.ts
@@ -1,0 +1,67 @@
+import { Component } from '@angular/core';
+import {
+  faChevronLeft,
+  IconDefinition,
+} from '@fortawesome/free-solid-svg-icons';
+import {
+  AppSettingPriceKey,
+  AppSettings,
+  PLAYER_CHARACTERS,
+} from '../../settings/settings.model';
+import { SettingsService } from '../../settings/settings.service';
+
+interface PriceField {
+  key: AppSettingPriceKey;
+  label: string;
+}
+
+@Component({
+  selector: 'app-settings-page',
+  standalone: false,
+  templateUrl: './settings-page.component.html',
+  styleUrls: ['./settings-page.component.scss'],
+})
+export class SettingsPageComponent {
+  faBackIcon: IconDefinition = faChevronLeft;
+  characters = [...PLAYER_CHARACTERS];
+  settings: AppSettings;
+
+  priceFields: PriceField[] = [
+    { key: 'hayPricePerAcre', label: 'Hay Price Per Acre' },
+    { key: 'grainPricePerAcre', label: 'Grain Price Per Acre' },
+    { key: 'fruitPricePerAcre', label: 'Fruit Price Per Acre' },
+    { key: 'cowPrice', label: 'Cow Price' },
+    { key: 'tractorPrice', label: 'Tractor Price' },
+    { key: 'harvesterPrice', label: 'Harvester Price' },
+  ];
+
+  constructor(private readonly settingsService: SettingsService) {
+    this.settings = this.settingsService.getSettings();
+  }
+
+  get playerSlots(): number[] {
+    return Array.from(
+      { length: this.settings.playerCount },
+      (_, index) => index,
+    );
+  }
+
+  onPriceChanged(key: AppSettingPriceKey, value: string | number): void {
+    this.settingsService.setPrice(key, value);
+    this.refreshSettings();
+  }
+
+  onPlayerCountChanged(value: string | number): void {
+    this.settingsService.setPlayerCount(value);
+    this.refreshSettings();
+  }
+
+  onPlayerCharacterChanged(index: number, character: string): void {
+    this.settingsService.setPlayerCharacter(index, character);
+    this.refreshSettings();
+  }
+
+  private refreshSettings(): void {
+    this.settings = this.settingsService.getSettings();
+  }
+}

--- a/apps/farming-game-calc/src/app/settings/settings.model.ts
+++ b/apps/farming-game-calc/src/app/settings/settings.model.ts
@@ -1,0 +1,40 @@
+export const PLAYER_CHARACTERS = [
+  'Satus Sam',
+  'Sunnyside Sidney',
+  'Toppenish Tom',
+  'Harrah Harry',
+  'Roza Ray',
+  'Wapato Willie',
+] as const;
+
+export type PlayerCharacter = (typeof PLAYER_CHARACTERS)[number];
+
+export interface AppSettings {
+  hayPricePerAcre: number;
+  grainPricePerAcre: number;
+  fruitPricePerAcre: number;
+  cowPrice: number;
+  tractorPrice: number;
+  harvesterPrice: number;
+  playerCount: number;
+  playerCharacters: string[];
+}
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  hayPricePerAcre: 2000,
+  grainPricePerAcre: 2000,
+  fruitPricePerAcre: 5000,
+  cowPrice: 500,
+  tractorPrice: 10000,
+  harvesterPrice: 10000,
+  playerCount: 1,
+  playerCharacters: [''],
+};
+
+export type AppSettingPriceKey =
+  | 'hayPricePerAcre'
+  | 'grainPricePerAcre'
+  | 'fruitPricePerAcre'
+  | 'cowPrice'
+  | 'tractorPrice'
+  | 'harvesterPrice';

--- a/apps/farming-game-calc/src/app/settings/settings.service.spec.ts
+++ b/apps/farming-game-calc/src/app/settings/settings.service.spec.ts
@@ -1,0 +1,72 @@
+import { SettingsService, SETTINGS_STORAGE_KEY } from './settings.service';
+import { DEFAULT_APP_SETTINGS } from './settings.model';
+
+describe('SettingsService', () => {
+  beforeEach(() => {
+    sessionStorage.removeItem(SETTINGS_STORAGE_KEY);
+  });
+
+  it('should load default settings when storage is empty', () => {
+    const service = new SettingsService();
+
+    expect(service.getSettings()).toEqual(DEFAULT_APP_SETTINGS);
+  });
+
+  it('should persist updated prices and player values', () => {
+    const service = new SettingsService();
+
+    service.setPrice('hayPricePerAcre', 2500);
+    service.setPlayerCount(3);
+    service.setPlayerCharacter(0, 'Satus Sam');
+    service.setPlayerCharacter(1, 'Harrah Harry');
+
+    const reloaded = new SettingsService();
+    const settings = reloaded.getSettings();
+
+    expect(settings.hayPricePerAcre).toBe(2500);
+    expect(settings.playerCount).toBe(3);
+    expect(settings.playerCharacters[0]).toBe('Satus Sam');
+    expect(settings.playerCharacters[1]).toBe('Harrah Harry');
+    expect(settings.playerCharacters[2]).toBe('');
+  });
+
+  it('should normalize malformed or invalid stored payloads', () => {
+    sessionStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        hayPricePerAcre: -1,
+        grainPricePerAcre: 'bad',
+        playerCount: 0,
+        playerCharacters: ['Invalid Character'],
+      }),
+    );
+
+    const service = new SettingsService();
+    const settings = service.getSettings();
+
+    expect(settings.hayPricePerAcre).toBe(DEFAULT_APP_SETTINGS.hayPricePerAcre);
+    expect(settings.grainPricePerAcre).toBe(
+      DEFAULT_APP_SETTINGS.grainPricePerAcre,
+    );
+    expect(settings.playerCount).toBe(DEFAULT_APP_SETTINGS.playerCount);
+    expect(settings.playerCharacters).toEqual(
+      DEFAULT_APP_SETTINGS.playerCharacters,
+    );
+  });
+
+  it('should ignore invalid updates', () => {
+    const service = new SettingsService();
+
+    service.setPrice('cowPrice', -10);
+    service.setPlayerCount(0);
+    service.setPlayerCharacter(100, 'Satus Sam');
+
+    const settings = service.getSettings();
+
+    expect(settings.cowPrice).toBe(DEFAULT_APP_SETTINGS.cowPrice);
+    expect(settings.playerCount).toBe(DEFAULT_APP_SETTINGS.playerCount);
+    expect(settings.playerCharacters).toEqual(
+      DEFAULT_APP_SETTINGS.playerCharacters,
+    );
+  });
+});

--- a/apps/farming-game-calc/src/app/settings/settings.service.ts
+++ b/apps/farming-game-calc/src/app/settings/settings.service.ts
@@ -1,0 +1,173 @@
+import { Injectable } from '@angular/core';
+import {
+  AppSettingPriceKey,
+  AppSettings,
+  DEFAULT_APP_SETTINGS,
+  PLAYER_CHARACTERS,
+} from './settings.model';
+
+export const SETTINGS_STORAGE_KEY = 'farming-game-calc-settings';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SettingsService {
+  private settings: AppSettings;
+
+  constructor() {
+    this.settings = this.loadSettings();
+  }
+
+  getSettings(): AppSettings {
+    return {
+      ...this.settings,
+      playerCharacters: [...this.settings.playerCharacters],
+    };
+  }
+
+  setPrice(key: AppSettingPriceKey, value: number | string): void {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return;
+    }
+
+    this.settings = {
+      ...this.settings,
+      [key]: parsed,
+    };
+    this.persist();
+  }
+
+  setPlayerCount(count: number | string): void {
+    const parsed = Math.floor(Number(count));
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return;
+    }
+
+    this.settings = this.normalize({
+      ...this.settings,
+      playerCount: parsed,
+    });
+    this.persist();
+  }
+
+  setPlayerCharacter(index: number, character: string): void {
+    if (index < 0 || index >= this.settings.playerCount) {
+      return;
+    }
+
+    const safeCharacter = PLAYER_CHARACTERS.includes(character as never)
+      ? character
+      : '';
+
+    const playerCharacters = [...this.settings.playerCharacters];
+    playerCharacters[index] = safeCharacter;
+
+    this.settings = this.normalize({
+      ...this.settings,
+      playerCharacters,
+    });
+    this.persist();
+  }
+
+  resetToDefaults(): void {
+    this.settings = {
+      ...DEFAULT_APP_SETTINGS,
+      playerCharacters: [...DEFAULT_APP_SETTINGS.playerCharacters],
+    };
+    this.persist();
+  }
+
+  private loadSettings(): AppSettings {
+    try {
+      const raw = sessionStorage.getItem(SETTINGS_STORAGE_KEY);
+      if (!raw) {
+        return {
+          ...DEFAULT_APP_SETTINGS,
+          playerCharacters: [...DEFAULT_APP_SETTINGS.playerCharacters],
+        };
+      }
+
+      const parsed = JSON.parse(raw);
+      return this.normalize(parsed);
+    } catch {
+      return {
+        ...DEFAULT_APP_SETTINGS,
+        playerCharacters: [...DEFAULT_APP_SETTINGS.playerCharacters],
+      };
+    }
+  }
+
+  private normalize(input: Partial<AppSettings>): AppSettings {
+    const settings: AppSettings = {
+      ...DEFAULT_APP_SETTINGS,
+      ...input,
+    };
+
+    settings.hayPricePerAcre = this.normalizeNonNegativeNumber(
+      settings.hayPricePerAcre,
+      DEFAULT_APP_SETTINGS.hayPricePerAcre,
+    );
+    settings.grainPricePerAcre = this.normalizeNonNegativeNumber(
+      settings.grainPricePerAcre,
+      DEFAULT_APP_SETTINGS.grainPricePerAcre,
+    );
+    settings.fruitPricePerAcre = this.normalizeNonNegativeNumber(
+      settings.fruitPricePerAcre,
+      DEFAULT_APP_SETTINGS.fruitPricePerAcre,
+    );
+    settings.cowPrice = this.normalizeNonNegativeNumber(
+      settings.cowPrice,
+      DEFAULT_APP_SETTINGS.cowPrice,
+    );
+    settings.tractorPrice = this.normalizeNonNegativeNumber(
+      settings.tractorPrice,
+      DEFAULT_APP_SETTINGS.tractorPrice,
+    );
+    settings.harvesterPrice = this.normalizeNonNegativeNumber(
+      settings.harvesterPrice,
+      DEFAULT_APP_SETTINGS.harvesterPrice,
+    );
+
+    const normalizedPlayerCount = Math.floor(Number(settings.playerCount));
+    settings.playerCount =
+      Number.isFinite(normalizedPlayerCount) && normalizedPlayerCount > 0
+        ? normalizedPlayerCount
+        : DEFAULT_APP_SETTINGS.playerCount;
+
+    const incomingCharacters = Array.isArray(settings.playerCharacters)
+      ? settings.playerCharacters
+      : [];
+
+    const normalizedCharacters = incomingCharacters.map((character) =>
+      PLAYER_CHARACTERS.includes(character as never) ? character : '',
+    );
+
+    while (normalizedCharacters.length < settings.playerCount) {
+      normalizedCharacters.push('');
+    }
+
+    settings.playerCharacters = normalizedCharacters.slice(
+      0,
+      settings.playerCount,
+    );
+
+    return settings;
+  }
+
+  private normalizeNonNegativeNumber(
+    value: number,
+    defaultValue: number,
+  ): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return defaultValue;
+    }
+
+    return parsed;
+  }
+
+  private persist(): void {
+    sessionStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(this.settings));
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated settings page for farming game calculations
- wire settings values into the main-page calculation flow
- refresh the about/main page UI spacing and alignment for consistency

## Testing
- verified the relevant app and e2e flows locally