### PR TITLE
Fix Pages artifact layout and add farming-game-calc deploy build

### DIFF
--- a/.github/workflows/deploy-sff-tracker.yml
+++ b/.github/workflows/deploy-sff-tracker.yml
@@ -25,11 +25,17 @@ jobs:
       #   - run: npx nx affected --target=lint --parallel=3
       #   - run: npx nx affected --target=test --parallel=3 --ci --code-coverage
       - run: npx nx build sff-tracker --parallel=3 --skipNxCache --base-href="/sff-tracker/"
+      - run: npx nx build farming-game-calc --parallel=3 --skipNxCache --base-href="/farming-game-calc/"
+      - name: Prepare Pages artifact directories
+        run: |
+          mkdir -p dist/pages/sff-tracker dist/pages/farming-game-calc
+          cp -R dist/apps/sff-tracker/browser/. dist/pages/sff-tracker/
+          cp -R dist/apps/farming-game-calc/browser/. dist/pages/farming-game-calc/
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Path of the directory containing the static assets.
-          path: dist/apps
+          path: dist/pages
 
   # Deploy job
   deploy:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deployment to support building and deploying both the `sff-tracker` and `farming-game-calc` applications. The main changes ensure that both apps are built and their static files are organized in a way that enables them to be served from separate subpaths on GitHub Pages.

**Deployment workflow enhancements:**

* Added a build step for the `farming-game-calc` app, ensuring both `sff-tracker` and `farming-game-calc` are built during the workflow.
* Introduced a step to prepare the `dist/pages` directory structure, copying the build outputs of both apps into their respective subfolders. This allows each app to be served from its own subpath.
* Updated the upload step to use the new `dist/pages` directory, ensuring the correct files are deployed to GitHub Pages.